### PR TITLE
MIST-505 Configure Libvirt guests to use Open vSwitch for network interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ Libvirt is the main struct for interacting with libvirt
 #### func  NewLibvirt
 
 ```go
-func NewLibvirt(uri string, max int) (*Libvirt, error)
+func NewLibvirt(uri string, zpool string, max int) (*Libvirt, error)
 ```
 NewLibvirt creates a new Libvirt object and initializes the connection limit
 

--- a/xml.go
+++ b/xml.go
@@ -31,7 +31,7 @@ func init() {
     <interface type="bridge">
       <source bridge="{{.Network}}" />
 	  <virtualport type="openvswitch" />
-	  {{if .Name}}<guest dev="{{.Name}}" />
+	  {{if .Name}}<guest dev="{{.Name}}" />{{end}}
       {{if .Mac}}<mac address="{{.Mac}}" />{{end}}
       {{if .Model}}<model type="{{.Model}}" />{{end}}
     </interface>

--- a/xml.go
+++ b/xml.go
@@ -29,10 +29,10 @@ func init() {
   <devices>
     {{range .Nics}}
     <interface type="bridge">
-      <guest dev="{{.Name}}" />
+      <source bridge="{{.Network}}" />
+	  <virtualport type="openvswitch" />
+	  {{if .Name}}<guest dev="{{.Name}}" />
       {{if .Mac}}<mac address="{{.Mac}}" />{{end}}
-      <source bridge='{{.Network}}'/>
-      <target dev="{{.Device}}" />
       {{if .Model}}<model type="{{.Model}}" />{{end}}
     </interface>
     {{end}}


### PR DESCRIPTION
A virtual network interface is created on guest startup and attached to the specified OVS bridge. On guest shutdown, it is removed.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mistifyio/mistify-agent-libvirt/18)
<!-- Reviewable:end -->
